### PR TITLE
Update: Replace Blade with Java SE HttpServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Web user interface for creating charts and diagrams.
 
 ## Usage
 
-You can run `java -jar java-charts-webui.jar` to start the server. The server will be bound to `127.0.0.1:80`, so you should be able to open http://localhost/ in your browser. Stop the server using `Ctrl`+`C`.
-
-I had some problems with Windows 11, but I can't figure out what caused them. So if in doubt, use a Linux system. Also make sure that only you can access the web server.
+You can run `java -jar java-charts-webui.jar` to start the server. The server will be bound to `127.0.0.1:80`, so you should be able to open http://localhost/ in your browser. Stop the server using `Ctrl`+`C`. Also make sure that only you can access to the server, as it is not secured in any way.
 
 Its use is largely self-explanatory: adjust the code for generating the functions and click on Send Code; the result will then be visible below.
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.hellokaton:blade-core:2.1.2.RELEASE'
     implementation 'org.knowm.xchart:xchart:3.8.8'
 }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -11,14 +11,14 @@
     <br><br>
     <input type="button" value="Send Code" onclick="sendCode();">
     <br><br>
-    <img src="${imgsrc}" alt="Java Charts Webui" id="chart-img">
+    <img src="{{imgsrc}}" alt="Java Charts Webui" id="chart-img">
     <script type="module">
         import { EditorView, basicSetup } from "https://esm.sh/codemirror"
         import { java } from "https://esm.sh/@codemirror/lang-java"
         import * as lang from "https://esm.sh/@codemirror/language"
         let view = new EditorView({
             parent: document.getElementById("code-editor"),
-            doc: ${codetext},
+            doc: `{{codetext}}`,
             extensions: [basicSetup, java()]
         });
         {


### PR DESCRIPTION
Replace Blade with Java SE HttpServer, so that this also works with Windows

This pull request makes significant changes to the web UI server for creating charts and diagrams. The main update is a complete replacement of the `Blade` web framework with Java's built-in `HttpServer`, simplifying dependencies and making the server more lightweight. The code for handling HTTP requests and rendering templates is now managed manually, and template placeholders in `index.html` have been updated to match the new rendering approach. The README is also updated to clarify security considerations.

**Web server refactor:**
* Replaced the `Blade` web framework with Java's built-in `HttpServer`, removing all references to `Blade` and rewriting the main server logic to handle HTTP requests and responses directly in `Main.java`. [[1]](diffhunk://#diff-328ff730f449c18acd4a1342163e35e947d20707e4710bf8abea62659b5bc807L1-R12) [[2]](diffhunk://#diff-328ff730f449c18acd4a1342163e35e947d20707e4710bf8abea62659b5bc807L73-R136)

**Template handling and rendering:**
* Added a new `getTemplate` method in `Main.java` to load and populate HTML templates with dynamic values, replacing the previous template rendering mechanism.
* Updated `index.html` to use `{{codetext}}` and `{{imgsrc}}` as placeholders for dynamic content, aligning with the new template system.

**Security and documentation:**
* Updated the `README.md` to remove outdated Windows troubleshooting advice and emphasize that the server is not secured, advising users to restrict access.