### PR TITLE
Update: Template caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.apache.commons:commons-text:1.14.0'
     implementation 'org.knowm.xchart:xchart:3.8.8'
 }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -11,14 +11,14 @@
     <br><br>
     <input type="button" value="Send Code" onclick="sendCode();">
     <br><br>
-    <img src="{{imgsrc}}" alt="Java Charts Webui" id="chart-img">
+    <img src="{{1}}" alt="Java Charts Webui" id="chart-img">
     <script type="module">
         import { EditorView, basicSetup } from "https://esm.sh/codemirror"
         import { java } from "https://esm.sh/@codemirror/lang-java"
         import * as lang from "https://esm.sh/@codemirror/language"
         let view = new EditorView({
             parent: document.getElementById("code-editor"),
-            doc: `{{codetext}}`,
+            doc: `{{0}}`,
             extensions: [basicSetup, java()]
         });
         {


### PR DESCRIPTION
- New dependency 'org.apache.commons:commons-text'
  for String substitution (more robust)
- Template caching (it's faster)

This pull request refactors the template rendering logic in `Main.java` to support more flexible template substitution, improves template caching, and updates the usage of template variables in both Java and HTML. The changes make it easier to add or modify templates and variables in the future.