### PR TITLE
Update

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -7,11 +7,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.tools.JavaCompiler;
 import org.apache.commons.text.StringSubstitutor;
@@ -135,20 +135,15 @@ public class Main {
         templates.put(path, new String(templateStream.readAllBytes(), StandardCharsets.UTF_8));
       }
     }
-    AtomicInteger ai = new AtomicInteger(0);
     return StringSubstitutor.replace(
         templates.get(path),
-        Arrays.stream(args)
-            .reduce(
-                new HashMap<>(),
-                (map, element) -> {
-                  map.put(ai.getAndIncrement() + "", element);
-                  return map;
-                },
-                (map1, map2) -> {
-                  map1.putAll(map2);
-                  return map1;
-                }),
+        IntStream.range(0, args.length)
+            .boxed()
+            .collect(
+                Collectors.toMap(
+                    i -> i + "", // key is the index as a string
+                    i -> args[i] // value is the corresponding argument
+                    )),
         "{{",
         "}}");
   }


### PR DESCRIPTION
This pull request refactors the way template arguments are mapped in the `getTemplate` method to use Java Streams more idiomatically and removes some unnecessary imports. The main logic for converting the `args` array to a map is now clearer and more concise.

Refactoring and code cleanup:

* Simplified the mapping of template arguments in the `getTemplate` method by replacing the use of `AtomicInteger` and `Arrays.stream().reduce()` with `IntStream.range()` and `Collectors.toMap()`, making the code more readable and efficient.
* Removed unused imports (`Arrays` and `AtomicInteger`) and added imports for `Collectors` and `IntStream` to support the new implementation.